### PR TITLE
build(deps): Update to `thiserror` version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.19"
 nom = "7.1.3"
 nom-derive = "0.10.1"
 pcap-file = "2.0.0"
-thiserror = "1.0.40"
+thiserror = "2"
 tokio = { version = "1.28.2", features = ["full"], optional = true }
 typed-builder = "0.14.0"
 libc = "0.2.146"


### PR DESCRIPTION
Depencency `thiserror` has some breaking changes, but non of them seem to impact `r-extcap`.

`cargo semver-checks` reports no breaking changes on the API.