### PR TITLE
style: Fix indentation in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,10 @@
 //!     5. [`CaptureStep`](crate::CaptureStep): described below.
 //!
 //!  4. In the [`CaptureStep`](crate::CaptureStep), start capturing packets from
-//!    the external interface, and write the packets to
-//!    [`CaptureStep::fifo`](crate::CaptureStep) using the
-//!    [`pcap_file`](https://docs.rs/pcap-file/latest/pcap_file/index.html)
-//!    crate.
+//!     the external interface, and write the packets to
+//!     [`CaptureStep::fifo`](crate::CaptureStep) using the
+//!     [`pcap_file`](https://docs.rs/pcap-file/latest/pcap_file/index.html)
+//!     crate.
 //!
 //! # Example
 //!


### PR DESCRIPTION
Fixes clippy warnings like this:
```
warning: doc list item missing indentation
  --> src/lib.rs:68:5
   |
68 | //!    the external interface, and write the packets to
   |     ^^^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
   |
68 | //!     the external interface, and write the packets to
   |        +
```