### PR TITLE
build(deps): Update env_logger to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ async = ["tokio", "async-trait"]
 sync = []
 
 [dev-dependencies]
-env_logger = "0.10.0"
 indoc = "2.0.1"
 regex = "1.8.4"
 lazy_static = "1.4.0"

--- a/extcap-example/Cargo.toml
+++ b/extcap-example/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main_async_read_control_pipe.rs"
 [dependencies]
 r-extcap = {version = "0.2.0", path = ".."}
 lazy_static = "1.4.0"
-env_logger = "0.10.0"
+env_logger = "0.11"
 regex = "1.7.1"
 clap = { version = "4.1.7", features = ["derive"] }
 anyhow = "1.0.69"


### PR DESCRIPTION
- Update the version number in the example
- Remove the unused dev-dependency