### PR TITLE
ci: Check compilation with minimal versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,13 @@ jobs:
     - name: Run tests
       run: cargo test -p r-extcap --verbose
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --all-features
+


### PR DESCRIPTION
- Update the lock file with the minimal versions defined in `Cargo.toml`
- Compile the code with those versions

This ensures all the used API are available in the minimal version of the dependencies.

The CI job uses a nightly feature for finding the minimal versions, but uses a binary to abstract it away. This same job has been running for a year without problems in `prost`.